### PR TITLE
base layout changes and table shortcode

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -62,26 +62,22 @@
         </div>
     {{ else if eq $left_sidebar true }}
         <div class="container">
-            <div class="columns">
-                <div class="column">
-                    {{ block "sidebar" . }}{{ end }}
-                    {{ partial "layout/sidebar" }}
-                </div>
-                <div class="column is-two-thirds">
-                    {{ block "main" . }}{{ end }}
-                </div>
+            <div class="column is-four-fifths">
+                {{ block "main" . }}{{ end }}
+            </div>
+            <div class="column">
+                {{ block "sidebar" . }}{{ end }}
+                {{ partial "layout/sidebar" }}
             </div>
         </div>
     {{ else }}
         <div class="container">
-            <div class="columns">
-                <div class="column is-two-thirds">
-                    {{ block "main" . }}{{ end }}
-                </div>
-                <div class="column">
-                    {{ block "sidebar" . }}{{ end }}
-                    {{ partial "layout/sidebar" }}
-                </div>
+            <div class="column is-four-fifths">
+                {{ block "main" . }}{{ end }}
+            </div>
+            <div class="column">
+                {{ block "sidebar" . }}{{ end }}
+                {{ partial "layout/sidebar" }}
             </div>
         </div>
     {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -62,8 +62,10 @@
         </div>
     {{ else if eq $left_sidebar true }}
         <div class="container">
-            <div class="column is-four-fifths">
-                {{ block "main" . }}{{ end }}
+            <div class="columns is-centered">
+                <div class="column is-four-fifths">
+                    {{ block "main" . }}{{ end }}
+                </div>
             </div>
             <div class="column">
                 {{ block "sidebar" . }}{{ end }}
@@ -72,8 +74,10 @@
         </div>
     {{ else }}
         <div class="container">
-            <div class="column is-four-fifths">
-                {{ block "main" . }}{{ end }}
+            <div class="columns is-centered">
+                <div class="column is-four-fifths">
+                    {{ block "main" . }}{{ end }}
+                </div>
             </div>
             <div class="column">
                 {{ block "sidebar" . }}{{ end }}

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,0 +1,6 @@
+{{ $htmlTable := .Inner | markdownify }}
+{{ $class := .Get 0 }}
+{{ $old := "<table>" }}
+{{ $new := printf "<table class=\"%s\">" $class }}
+{{ $htmlTable := replace $htmlTable $old $new }}
+{{ $htmlTable | safeHTML }}


### PR DESCRIPTION
 - changed base layout to reposition the sidebar ad column to the bottom of the page
 - increased content column size and repositioned it to the center
 - added new table shortcode to make tables look less crappy
    - wrap around a markdown table to make it work