### PR TITLE
layouts: sort game compatdb list by title

### DIFF
--- a/layouts/game/list.html
+++ b/layouts/game/list.html
@@ -34,7 +34,7 @@
             </tr>
         </thead>
         <tbody class="is-size-7">
-            {{ range .Pages }}
+            {{ range sort .Pages "Params.title" "asc" }}
             {{ $rating := index .Site.Data.compatibility .Params.compatibility }}
             <tr data-key="{{ .Params.section_id }}">
                 <td data-title="{{ .Params.title }}">


### PR DESCRIPTION
The list is currently not sorted. It appears to be sorted, but actually the A-Z sort repeats itself a few times. This makes it difficult and error-prone to scroll through and find a game by name.

This PR updates the game list to be sorted by game title, ascending.