### PR TITLE
layouts: Add full content to RSS entries

### DIFF
--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,4 +1,4 @@
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
       <title>{{ .Title }} on {{ .Site.Title }} </title>
     <link>{{ .Permalink }}</link>
@@ -14,6 +14,7 @@
       <author>{{ .Params.Author }}</author>
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
+      <content:encoded>{{ .Content | html }}</content:encoded>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
Adds the full content of blog posts to RSS entries, by using the `<content:encoded>` tag.

Example of how it is fetched by Miniflux:
![image](https://user-images.githubusercontent.com/3867850/233100123-97be9e4f-db61-40bb-aa32-e773ae2a9e39.png)

Fixes https://github.com/yuzu-emu/yuzu-emu.github.io/issues/299

Resources:
* https://web.resource.org/rss/1.0/modules/content/